### PR TITLE
Maven parent groupId needs .extensions at the end

### DIFF
--- a/gwt/samples/gwt-chat/pom.xml
+++ b/gwt/samples/gwt-chat/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.atmosphere</groupId>
+        <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt-project</artifactId>
         <version>1.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>


### PR DESCRIPTION
Maven parent groupId needs .extensions at the end
