### PR TITLE
Update webSocketsEnabled flag to false when WebSockets not available on server

### DIFF
--- a/gwt/modules/atmosphere-gwt-client/src/main/java/org/atmosphere/gwt/client/AtmosphereClient.java
+++ b/gwt/modules/atmosphere-gwt-client/src/main/java/org/atmosphere/gwt/client/AtmosphereClient.java
@@ -599,6 +599,7 @@ public class AtmosphereClient implements UserInterface {
             if (transport instanceof WebSocketCometTransport && webSocketSuccessful == false) {
                 // server doesn't support WebSocket's degrade the connection ...
                 logger.info("Server does not support WebSockets");
+                webSocketsEnabled = false;
                 transport = GWT.create(CometTransport.class);
                 transport.initiate(AtmosphereClient.this, this);
                 transport.connect(++connectionCount);


### PR DESCRIPTION
When working with AWS ELB, we ran into an issue where WebSockets were not available. However, there is no way in the client code to determine if the WebSocket connection failed. This seems like a straightforward solution since WebSockets are no longer enabled.
