### PR TITLE
Fix for serializing transport when using IE6

### DIFF
--- a/gwt/modules/atmosphere-gwt-client/src/main/java/org/atmosphere/gwt/client/impl/StreamingProtocolTransport.java
+++ b/gwt/modules/atmosphere-gwt-client/src/main/java/org/atmosphere/gwt/client/impl/StreamingProtocolTransport.java
@@ -130,7 +130,7 @@ abstract public class StreamingProtocolTransport extends BaseCometTransport {
                 case 'r':
                 case 'f':
                     try {
-                        messages.add(parse(message));
+                    	 messages.add(parse(message.substring(2)));
                     } catch (SerializationException e) {
                         listener.onError(e, true);
                     }

--- a/gwt/modules/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/StreamingProtocolResponseWriter.java
+++ b/gwt/modules/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/StreamingProtocolResponseWriter.java
@@ -145,11 +145,12 @@ abstract public class StreamingProtocolResponseWriter extends ManagedStreamRespo
                 } else {
                     writer.append(']');
                 }
+                writer.append(string).append('\n');
             } else {
                 string = serialize(message);
+                writer.append('f').append(";").append(string).append('\n');
             }
 
-            writer.append(string).append('\n');
         }
     }
 


### PR DESCRIPTION
As discussed in the following thread here is the pull request:

https://groups.google.com/forum/?fromgroups=#!topic/atmosphere-framework/pml_UD2dCKA
