### PR TITLE
jsonp-polling does not work in socketio extension

### DIFF
--- a/socketio/modules/pom.xml
+++ b/socketio/modules/pom.xml
@@ -64,6 +64,10 @@
 			<version>2.2</version>
 			<scope>provided</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/socketio/modules/src/main/java/org/atmosphere/socketio/transport/AbstractTransport.java
+++ b/socketio/modules/src/main/java/org/atmosphere/socketio/transport/AbstractTransport.java
@@ -133,6 +133,9 @@ public abstract class AbstractTransport implements Transport {
         } else if ("POST".equals(request.getMethod())) {
             try {
                 String data = decodePostData(request.getContentType(), extractString(request.getReader()));
+                if (data == null || data.length() == 0) {
+                    data = SocketIOSessionManagerImpl.mapper.readValue(request.getParameter("d"), String.class);
+                }
                 request.setAttribute(POST_MESSAGE_RECEIVED, data);
                 // Set back the body
                 request.body(data);

--- a/socketio/modules/src/main/java/org/atmosphere/socketio/transport/JSONPPollingTransport.java
+++ b/socketio/modules/src/main/java/org/atmosphere/socketio/transport/JSONPPollingTransport.java
@@ -15,6 +15,7 @@
  */
 package org.atmosphere.socketio.transport;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.atmosphere.cpr.AtmosphereHandler;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResourceImpl;
@@ -51,7 +52,7 @@ public class JSONPPollingTransport extends XHRTransport {
             logger.trace("calling from " + this.getClass().getName() + " : " + "writeData(string) = " + data);
 
             response.setContentType("text/javascript; charset=UTF-8");
-            response.getOutputStream().print("io.j[" + jsonpIndex + "](\"" + data + "\");");
+            response.getOutputStream().print("io.j[" + jsonpIndex + "](\"" + StringEscapeUtils.escapeEcmaScript(data) + "\");");
 
             logger.trace("WRITE SUCCESS calling from " + this.getClass().getName() + " : " + "writeData(string) = " + data);
 

--- a/socketio/modules/src/main/java/org/atmosphere/socketio/transport/XHRTransport.java
+++ b/socketio/modules/src/main/java/org/atmosphere/socketio/transport/XHRTransport.java
@@ -261,6 +261,9 @@ public abstract class XHRTransport extends AbstractTransport {
                         if (data == null) {
                             data = decodePostData(request.getContentType(), extractString(request.getReader()));
                         }
+                        if (data == null || data.length() == 0) {
+                            data = SocketIOSessionManagerImpl.mapper.readValue(request.getParameter("d"), String.class);
+                        }
                         if (data != null && data.length() > 0) {
 
                             List<SocketIOPacketImpl> list = SocketIOPacketImpl.parse(data);


### PR DESCRIPTION
The current `JSONPPollingTransport` implementation
1. does not escape the JavaScript string before inserting it into the JSONP response
2. inherits `handle()` from `XHRTransport`, which only checks the request body (for jsonp-polling, the data is sent in a parameter `d` ([source](http://showmetheco.de/articles/2011/8/socket-io-for-backend-developers.html)))
