### PR TITLE
onConnected not working properly when we work with comet via IFrame

### DIFF
--- a/gwt/modules/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/IFrameResponseWriter.java
+++ b/gwt/modules/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/IFrameResponseWriter.java
@@ -73,7 +73,7 @@ public class IFrameResponseWriter extends ManagedStreamResponseWriter {
         }
         writer.append(MID);
         writer.append(Integer.toString(resource.getHeartBeatInterval()));
-        writer.append(',').append(String.valueOf(resource.getConnectionUUID()));
+        writer.append(',').append("'").append(String.valueOf(resource.getConnectionUUID())).append("'");
         writer.append(TAIL);
     }
 


### PR DESCRIPTION
... because connectionUUID had no quotes inside a script like: parent.window.c(5000,39777f16-6131-4a3a-909f-78fef017aba7);
