### PR TITLE
GWT-20: Remove logging from library module

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-client/src/main/resources/org/atmosphere/gwt20/AtmosphereGwt20.gwt.xml
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/resources/org/atmosphere/gwt20/AtmosphereGwt20.gwt.xml
@@ -15,7 +15,6 @@
     <inherits name="com.google.gwt.user.User"/>
     <inherits name="com.google.gwt.rpc.RPC"/>
     <inherits name="com.google.web.bindery.autobean.AutoBean"/>
-    <inherits name="com.google.gwt.logging.Logging"/>
     
     <generate-with class="org.atmosphere.gwt20.rebind.SerializerGenerator">
         <when-type-assignable class="org.atmosphere.gwt20.client.GwtRpcClientSerializer"/>


### PR DESCRIPTION
The 'inherits' should be in the samples only, not the library module.
