### PR TITLE
Created HazelcastSerializedBroadcaster to publish the serialized message objects

### DIFF
--- a/hazelcast/modules/pom.xml
+++ b/hazelcast/modules/pom.xml
@@ -43,6 +43,18 @@
     </build>
     <dependencies>
         <dependency>
+        	<groupId>junit</groupId>
+        	<artifactId>junit</artifactId>
+        	<version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.mockito</groupId>
+        	<artifactId>mockito-all</artifactId>
+        	<version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.atmosphere</groupId>
             <artifactId>atmosphere-jersey</artifactId>
             <version>${atmosphere-version}</version>

--- a/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastBroadcaster.java
+++ b/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastBroadcaster.java
@@ -104,4 +104,13 @@ public class HazelcastBroadcaster extends AbstractBroadcasterProxy {
         topic.publish(message.toString());
     }
 
+    /**
+     * Get the Hazelcast topic
+     * @return topic
+     */
+    protected ITopic getTopic() {
+        return topic;
+    }
+
+
 }

--- a/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastSerializedBroadcaster.java
+++ b/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastSerializedBroadcaster.java
@@ -1,0 +1,18 @@
+package org.atmosphere.plugin.hazelcast;
+
+/**
+ * Simple {@link org.atmosphere.cpr.Broadcaster} implementation based on Hazelcast for {@link java.io.Serializable} objects
+ * This broadcaster will publish the object as is to the Hazelcast topic queue and rely on Hazelcast's capability to serialize objects
+ *
+ * @author Ruby Boyarski
+ */
+public class HazelcastSerializedBroadcaster extends HazelcastBroadcaster {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void outgoingBroadcast(Object message) {
+        getTopic().publish(message);
+    }
+}

--- a/hazelcast/modules/src/test/java/org/atmosphere/plugin/hazelcast/HazelcastSerializedBroadcasterTest.java
+++ b/hazelcast/modules/src/test/java/org/atmosphere/plugin/hazelcast/HazelcastSerializedBroadcasterTest.java
@@ -1,0 +1,25 @@
+package org.atmosphere.plugin.hazelcast;
+
+
+import com.hazelcast.core.ITopic;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by rubyboy on 13/12/13.
+ */
+public class HazelcastSerializedBroadcasterTest {
+
+    @Test
+    public void test() {
+        HazelcastSerializedBroadcaster hazelcastSerializedBroadcaster = spy(new HazelcastSerializedBroadcaster());
+        ITopic topic = mock(ITopic.class);
+        when(hazelcastSerializedBroadcaster.getTopic()).thenReturn(topic);
+        Object message = new Object();
+        hazelcastSerializedBroadcaster.outgoingBroadcast(message);
+        verify(hazelcastSerializedBroadcaster,times(1)).getTopic();
+        verify(topic,times(1)).publish(message);
+    }
+
+}


### PR DESCRIPTION
- Created HazelcastSerializedBroadcaster to publish the message object itself (letting Hazelcast serialize it)
- Also added JUnit and Mockito test dependencies, including a small test to the HazelcastSerializedBroadcaster
