### PR TITLE
Modified interface of gwt20 to make it easier to test

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/Atmosphere.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/Atmosphere.java
@@ -21,27 +21,38 @@ import com.google.gwt.core.client.JavaScriptObject;
  *
  * @author jotec
  */
-public final class Atmosphere extends JavaScriptObject {
- 
+public final class Atmosphere extends JavaScriptObject implements AtmosphereSubscriber {
+
+    public static AtmosphereSubscriber createAtmosphereSubscriber() {
+        return create();
+    }
+
     public static native Atmosphere create() /*-{
         return $wnd.atmosphere;
     }-*/;
-    
-    public AtmosphereRequest subscribe(AtmosphereRequestConfig requestConfig) {
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.AtmosphereSubscriber#subscribe(org.atmosphere.gwt20.client.AtmosphereRequestConfig)
+     */
+    @Override
+    public AtmosphereServerRequest subscribe(RequestConfig requestConfig) {
         AtmosphereRequest r = subscribeImpl(requestConfig);
         r.setOutboundSerializer(requestConfig.getOutboundSerializer());
         return r;
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.AtmosphereSubscriber#unsubscribe()
+     */
+    @Override
     public native void unsubscribe() /*-{
       this.unsubscribe();
     }-*/;
-    
-    private native AtmosphereRequest subscribeImpl(AtmosphereRequestConfig requestConfig) /*-{
+
+    private native AtmosphereRequest subscribeImpl(RequestConfig requestConfig) /*-{
       return this.subscribe(requestConfig);
     }-*/;
-    
+
     protected Atmosphere() {
     }
- 
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereClientTimeoutHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereClientTimeoutHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author Jeanfrancois Arcand
  */
 public interface AtmosphereClientTimeoutHandler {
-    public void onClientTimeout(AtmosphereRequest request);
+    public void onClientTimeout(AtmosphereServerRequest request);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereCloseHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereCloseHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereCloseHandler {
-    public void onClose(AtmosphereResponse response);
+    public void onClose(AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereErrorHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereErrorHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereErrorHandler {
-    public void onError(AtmosphereResponse response);
+    public void onError(AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereFailureToReconnectHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereFailureToReconnectHandler.java
@@ -19,5 +19,5 @@ package org.atmosphere.gwt20.client;
  * @author sjardine
  */
 public interface AtmosphereFailureToReconnectHandler {
-    public void onFailureToReconnect(AtmosphereRequestConfig request, AtmosphereResponse response);
+    public void onFailureToReconnect(RequestConfig request, AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessage.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessage.java
@@ -15,7 +15,6 @@
  */
 package org.atmosphere.gwt20.client;
 
-import java.io.InputStream;
 import java.io.Serializable;
 
 /**

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessageHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessageHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereMessageHandler {
-    public void onMessage(AtmosphereResponse response);
+    public void onMessage(AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessagePublishedHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereMessagePublishedHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereMessagePublishedHandler {
-    public void onMessagePublished(AtmosphereRequestConfig request, AtmosphereResponse response);
+    public void onMessagePublished(RequestConfig request, AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereOpenHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereOpenHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereOpenHandler {
-    public void onOpen(AtmosphereResponse response);
+    public void onOpen(AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereReconnectHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereReconnectHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereReconnectHandler {
-    public void onReconnect(AtmosphereRequestConfig request, AtmosphereResponse response);
+    public void onReconnect(RequestConfig request, AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereReopenHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereReopenHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereReopenHandler {
-    public void onReopen(AtmosphereResponse response);
+    public void onReopen(AtmosphereServerResponse response);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequest.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequest.java
@@ -23,23 +23,39 @@ import java.util.logging.Logger;
  *
  * @author rinchen tenpel
  */
-public final class AtmosphereRequest extends JavaScriptObject {
+public final class AtmosphereRequest extends JavaScriptObject implements AtmosphereServerRequest {
   
   static final Logger logger = Logger.getLogger("AtmosphereRequest");
   
-  public void push(Object message) throws SerializationException {
+  /* (non-Javadoc)
+ * @see org.atmosphere.gwt20.client.AtmosphereMessageManager#push(java.lang.Object)
+ */
+@Override
+public void push(Object message) throws SerializationException {
     this.pushImpl(getOutboundSerializer().serialize(message));
   }
   
-  public native void pushImpl(String message) /*-{
+  /* (non-Javadoc)
+ * @see org.atmosphere.gwt20.client.AtmosphereMessageManager#pushImpl(java.lang.String)
+ */
+@Override
+public native void pushImpl(String message) /*-{
     this.push(message);
   }-*/;
   
-  public void pushLocal(Object message) throws SerializationException {
+  /* (non-Javadoc)
+ * @see org.atmosphere.gwt20.client.AtmosphereMessageManager#pushLocal(java.lang.Object)
+ */
+@Override
+public void pushLocal(Object message) throws SerializationException {
     this.pushLocalImpl(getOutboundSerializer().serialize(message));
   }
   
-  public native void pushLocalImpl(String message) /*-{
+  /* (non-Javadoc)
+ * @see org.atmosphere.gwt20.client.AtmosphereMessageManager#pushLocalImpl(java.lang.String)
+ */
+@Override
+public native void pushLocalImpl(String message) /*-{
     this.pushLocal(message);
   }-*/;
   
@@ -55,7 +71,11 @@ public final class AtmosphereRequest extends JavaScriptObject {
     return this.serializer;
   }-*/;
 
-  public native String getUUID() /*-{
+  /* (non-Javadoc)
+ * @see org.atmosphere.gwt20.client.AtmosphereMessageManager#getUUID()
+ */
+@Override
+public native String getUUID() /*-{
     return String(this.getUUID());
   }-*/;
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
@@ -26,71 +26,27 @@ import java.util.logging.Logger;
  *
  * @author p.havelaar
  */
-public final class AtmosphereRequestConfig extends JavaScriptObject {
-    
+public final class AtmosphereRequestConfig extends JavaScriptObject implements RequestConfig {
+
     private static final Logger logger = Logger.getLogger(AtmosphereRequestConfig.class.getName());
 
-    public enum Transport {
-        SESSION,
-        LONG_POLLING, 
-        STREAMING, 
-        JSONP, 
-        SSE, 
-        WEBSOCKET;
-        
-        @Override
-        public String toString() {
-            switch(this) {
-                default:
-                case SESSION: return "session";
-                case LONG_POLLING: return "long-polling";
-                case STREAMING : return "streaming"; 
-                case JSONP: return "jsonp";
-                case SSE: return "sse";
-                case WEBSOCKET: return "websocket";
-            }
-        }
-
-        public static Transport fromString(String s) {
-            for (Transport t : Transport.values()) {
-                if (t.toString().equals(s)) {
-                    return t;
-                }
-            }
-            return null;
-        }
-    };
-    
-    public enum Flags {
-        enableXDR,
-        rewriteURL,
-        attachHeadersAsQueryString,
-        withCredentials,
-        trackMessageLength,
-        shared,
-        readResponsesHeaders,
-        dropAtmosphereHeaders,
-        executeCallbackBeforeReconnect,
-        enableProtocol
-    }
-    
     /**
      * use the same serializer for inbound and outbound
      * @param serializer
-     * @return 
+     * @return
      */
-    public static AtmosphereRequestConfig create(ClientSerializer serializer) {
+    public static RequestConfig create(ClientSerializer serializer) {
         return create(serializer, serializer);
     }
-    
+
     /**
      * specify a different serializer for inbound and outbound
-     * 
+     *
      * @param inbound
      * @param outbound
-     * @return 
+     * @return
      */
-    public static AtmosphereRequestConfig create(ClientSerializer inbound, ClientSerializer outbound) {
+    public static RequestConfig create(ClientSerializer inbound, ClientSerializer outbound) {
         AtmosphereRequestConfig r = createImpl();
         MessageHandlerWrapper w = new MessageHandlerWrapper(inbound);
         r.setMessageHandlerImpl(w);
@@ -101,19 +57,31 @@ public final class AtmosphereRequestConfig extends JavaScriptObject {
         r.setOutboundSerializer(outbound);
         return r;
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setFlags(org.atmosphere.gwt20.client.AtmosphereRequestConfig.Flags)
+     */
+    @Override
     public void setFlags(Flags... flags) {
       for (Flags f :flags) {
         setFlagImpl(f.name(), true);
       }
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#clearFlags(org.atmosphere.gwt20.client.AtmosphereRequestConfig.Flags)
+     */
+    @Override
     public void clearFlags(Flags... flags) {
       for (Flags f :flags) {
         setFlagImpl(f.name(), false);
       }
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setHeader(java.lang.String, java.lang.String)
+     */
+    @Override
     public native void setHeader(String name, String value) /*-{
        if (typeof this.headers == 'undefined') {
          this.headers = {};
@@ -121,196 +89,294 @@ public final class AtmosphereRequestConfig extends JavaScriptObject {
         this.headers[name] = value;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMaxReconnectOnClose(int)
+     */
+    @Override
     public native void setMaxReconnectOnClose(int maxReconnectOnClose) /*-{
         this.maxReconnectOnClose = maxReconnectOnClose;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setContentType(java.lang.String)
+     */
+    @Override
     public native void setContentType(String contentType) /*-{
         this.contentType = contentType;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setUrl(java.lang.String)
+     */
+    @Override
     public native void setUrl(String url) /*-{
         this.url = url;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setConnectTimeout(int)
+     */
+    @Override
     public native void setConnectTimeout(int connectTimeout) /*-{
         this.connectTimeout = connectTimeout;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setReconnectInterval(int)
+     */
+    @Override
     public native void setReconnectInterval(int reconnectInterval) /*-{
         this.reconnectInterval = reconnectInterval;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setTimeout(int)
+     */
+    @Override
     public native void setTimeout(int timeout) /*-{
         this.timeout = timeout;
     }-*/;
 
-	public native void setLogLevel(String logLevel) /*-{
-	    this.logLevel = logLevel;
-	}-*/;
-	
-	public native void setMaxRequest(int maxRequest) /*-{
-	    this.maxRequest = maxRequest;
-	}-*/;
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setLogLevel(java.lang.String)
+     */
+    @Override
+    public native void setLogLevel(String logLevel) /*-{
+        this.logLevel = logLevel;
+    }-*/;
 
-	public native void setMaxStreamingLength(int maxStreamingLength) /*-{
-	    this.maxStreamingLength = maxStreamingLength;
-	}-*/;
-	
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMaxRequest(int)
+     */
+    @Override
+    public native void setMaxRequest(int maxRequest) /*-{
+        this.maxRequest = maxRequest;
+    }-*/;
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMaxStreamingLength(int)
+     */
+    @Override
+    public native void setMaxStreamingLength(int maxStreamingLength) /*-{
+        this.maxStreamingLength = maxStreamingLength;
+    }-*/;
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMethod(com.google.gwt.http.client.RequestBuilder.Method)
+     */
+    @Override
     public void setMethod(Method method) {
         setMethodImpl(method.toString());
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setFallbackMethod(com.google.gwt.http.client.RequestBuilder.Method)
+     */
+    @Override
     public void setFallbackMethod(Method method) {
         setFallbackMethodImpl(method.toString());
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setTransport(org.atmosphere.gwt20.client.AtmosphereRequestConfig.Transport)
+     */
+    @Override
     public void setTransport(Transport transport) {
         setTransportImpl(transport.toString());
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setFallbackTransport(org.atmosphere.gwt20.client.AtmosphereRequestConfig.Transport)
+     */
+    @Override
     public void setFallbackTransport(Transport transport) {
         setFallbackTransportImpl(transport.toString());
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setOpenHandler(org.atmosphere.gwt20.client.AtmosphereOpenHandler)
+     */
+    @Override
     public native void setOpenHandler(AtmosphereOpenHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onOpen = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereOpenHandler::onOpen(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereOpenHandler::onOpen(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onOpen = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setReopenHandler(org.atmosphere.gwt20.client.AtmosphereReopenHandler)
+     */
+    @Override
     public native void setReopenHandler(AtmosphereReopenHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onReopen = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereReopenHandler::onReopen(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereReopenHandler::onReopen(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onReopen = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setCloseHandler(org.atmosphere.gwt20.client.AtmosphereCloseHandler)
+     */
+    @Override
     public native void setCloseHandler(AtmosphereCloseHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onClose = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereCloseHandler::onClose(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereCloseHandler::onClose(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onClose = null;
         }
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setClientTimeoutHandler(org.atmosphere.gwt20.client.AtmosphereClientTimeoutHandler)
+     */
+    @Override
     public native void setClientTimeoutHandler(AtmosphereClientTimeoutHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onClientTimeout = $entry(function(request) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereClientTimeoutHandler::onClientTimeout(Lorg/atmosphere/gwt20/client/AtmosphereRequest;)(request);
+                handler.@org.atmosphere.gwt20.client.AtmosphereClientTimeoutHandler::onClientTimeout(Lorg/atmosphere/gwt20/client/AtmosphereServerRequest;)(request);
             });
         } else {
             this.onClientTimeout = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMessageHandler(org.atmosphere.gwt20.client.AtmosphereMessageHandler)
+     */
+    @Override
     public void setMessageHandler(AtmosphereMessageHandler handler) {
         getMessageHandlerWrapper().messageHandler = handler;
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setLocalMessageHandler(org.atmosphere.gwt20.client.AtmosphereMessageHandler)
+     */
+    @Override
     public void setLocalMessageHandler(AtmosphereMessageHandler handler) {
         getLocalMessageHandlerWrapper().messageHandler = handler;
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setErrorHandler(org.atmosphere.gwt20.client.AtmosphereErrorHandler)
+     */
+    @Override
     public native void setErrorHandler(AtmosphereErrorHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onError = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereErrorHandler::onError(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereErrorHandler::onError(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onError = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setReconnectHandler(org.atmosphere.gwt20.client.AtmosphereReconnectHandler)
+     */
+    @Override
     public native void setReconnectHandler(AtmosphereReconnectHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onReconnect = $entry(function(request, response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereReconnectHandler::onReconnect(Lorg/atmosphere/gwt20/client/AtmosphereRequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(request, response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereReconnectHandler::onReconnect(Lorg/atmosphere/gwt20/client/RequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(request, response);
             });
         } else {
             this.onReconnect = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setFailureToReconnectHandler(org.atmosphere.gwt20.client.AtmosphereFailureToReconnectHandler)
+     */
+    @Override
     public native void setFailureToReconnectHandler(AtmosphereFailureToReconnectHandler handler) /*-{
-    	var self = this;
-    	if (handler != null) {
-        	this.onFailureToReconnect = $entry(function(request, response) {
-            	handler.@org.atmosphere.gwt20.client.AtmosphereFailureToReconnectHandler::onFailureToReconnect(Lorg/atmosphere/gwt20/client/AtmosphereRequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(request, response);
-        	});
-    	} else {
-        	this.onFailureToReconnect = null;
-    	}
-	}-*/;
-    
+        var self = this;
+        if (handler != null) {
+            this.onFailureToReconnect = $entry(function(request, response) {
+                handler.@org.atmosphere.gwt20.client.AtmosphereFailureToReconnectHandler::onFailureToReconnect(Lorg/atmosphere/gwt20/client/RequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(request, response);
+            });
+        } else {
+            this.onFailureToReconnect = null;
+        }
+    }-*/;
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setMessagePublishedHandler(org.atmosphere.gwt20.client.AtmosphereMessagePublishedHandler)
+     */
+    @Override
     public native void setMessagePublishedHandler(AtmosphereMessagePublishedHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onMessagePublished = $entry(function(request, response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereMessagePublishedHandler::onMessagePublished(Lorg/atmosphere/gwt20/client/AtmosphereRequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(request, response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereMessagePublishedHandler::onMessagePublished(Lorg/atmosphere/gwt20/client/RequestConfig;Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(request, response);
             });
         } else {
             this.onMessagePublished = null;
         }
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.RequestConfig#setTransportFailureHandler(org.atmosphere.gwt20.client.AtmosphereTransportFailureHandler)
+     */
+    @Override
     public native void setTransportFailureHandler(AtmosphereTransportFailureHandler handler) /*-{
         var self = this;
         if (handler != null) {
             this.onTransportFailure = $entry(function(errorMsg, request) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereTransportFailureHandler::onTransportFailure(Ljava/lang/String;Lorg/atmosphere/gwt20/client/AtmosphereRequest;)(errorMsg, request);
+                handler.@org.atmosphere.gwt20.client.AtmosphereTransportFailureHandler::onTransportFailure(Ljava/lang/String;Lorg/atmosphere/gwt20/client/AtmosphereServerRequest;)(errorMsg, request);
             });
         } else {
             this.onTransportFailure = null;
         }
     }-*/;
-    
-    native void setOutboundSerializer(ClientSerializer serializer) /*-{
+
+    @Override
+    public native void setOutboundSerializer(ClientSerializer serializer) /*-{
       this.serializer = serializer;
     }-*/;
 
-    native ClientSerializer getOutboundSerializer() /*-{
+    @Override
+    public native ClientSerializer getOutboundSerializer() /*-{
       return this.serializer;
     }-*/;
-    
-    
+
+
     protected AtmosphereRequestConfig() {
     }
-    
+
     private static AtmosphereRequestConfig createImpl() {
       return (AtmosphereRequestConfig) JavaScriptObject.createObject();
     }
-    
+
     private native void setMethodImpl(String method) /*-{
       this.method = method;
     }-*/;
-  
+
     static class MessageHandlerWrapper implements AtmosphereMessageHandler {
 
         ClientSerializer serializer;
         AtmosphereMessageHandler messageHandler;
-        
+
         public MessageHandlerWrapper(ClientSerializer serializer) {
             this.serializer = serializer;
         }
-       
+
         @Override
-        public void onMessage(AtmosphereResponse response) {
+        public void onMessage(AtmosphereServerResponse response) {
             try {
                 if (response.getResponseBody().trim().length() == 0) {
                   return;
@@ -325,41 +391,41 @@ public final class AtmosphereRequestConfig extends JavaScriptObject {
             }
         }
     }
-    
+
     native MessageHandlerWrapper getMessageHandlerWrapper() /*-{
         return this.messageHandler;
     }-*/;
-    
+
     native MessageHandlerWrapper getLocalMessageHandlerWrapper() /*-{
         return this.localMessageHandler;
     }-*/;
-    
+
     private native void setTransportImpl(String transport) /*-{
       this.transport = transport;
     }-*/;
-    
+
     private native void setFallbackTransportImpl(String transport) /*-{
       this.fallbackTransport = transport;
     }-*/;
-        
+
     private native void setMessageHandlerImpl(AtmosphereMessageHandler handler) /*-{
         var self = this;
         this.messageHandler = handler;
         if (handler != null) {
             this.onMessage = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereMessageHandler::onMessage(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereMessageHandler::onMessage(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onMessage = null;
         }
     }-*/;
-  
+
     private native void setLocalMessageHandlerImpl(AtmosphereMessageHandler handler) /*-{
         var self = this;
         this.localMessageHandler = handler;
         if (handler != null) {
             this.onLocalMessage = $entry(function(response) {
-                handler.@org.atmosphere.gwt20.client.AtmosphereMessageHandler::onMessage(Lorg/atmosphere/gwt20/client/AtmosphereResponse;)(response);
+                handler.@org.atmosphere.gwt20.client.AtmosphereMessageHandler::onMessage(Lorg/atmosphere/gwt20/client/AtmosphereServerResponse;)(response);
             });
         } else {
             this.onLocalMessage = null;

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereResponse.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereResponse.java
@@ -19,13 +19,13 @@ import com.google.gwt.core.client.JavaScriptObject;
 import java.util.Collections;
 import java.util.List;
 
-import org.atmosphere.gwt20.client.AtmosphereRequestConfig.Transport;
+import org.atmosphere.gwt20.client.RequestConfig.Transport;
 
 /**
  *
  * @author jotec
  */
-public final class AtmosphereResponse extends JavaScriptObject {
+public final class AtmosphereResponse extends JavaScriptObject implements AtmosphereServerResponse {
 
     public enum State {
         MESSAGE_RECEIVED,
@@ -34,7 +34,7 @@ public final class AtmosphereResponse extends JavaScriptObject {
         RE_OPENING,
         CLOSED,
         ERROR;
-        
+
         @Override
         public String toString() {
             switch(this) {
@@ -56,19 +56,26 @@ public final class AtmosphereResponse extends JavaScriptObject {
             return State.ERROR;
         }
     }
-    /**
-     * See com.google.gwt.http.client.Response for status codes
-     * 
-     * @return 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getStatus()
      */
+    @Override
     public native int getStatus() /*-{
        return this.status;
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getReasonPhrase()
+     */
+    @Override
     public native String getReasonPhrase() /*-{
         return this.reasonPhrase;
     }-*/;
 
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getMessages()
+     */
+    @Override
     public <T> List<T> getMessages() {
        Object containedMessage = getMessageObject();
        if (containedMessage == null) {
@@ -79,34 +86,51 @@ public final class AtmosphereResponse extends JavaScriptObject {
           return (List<T>) Collections.singletonList(containedMessage);
        }
     }
-        
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getResponseBody()
+     */
+    @Override
     public native String getResponseBody() /*-{
         return this.responseBody;
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getHeader(java.lang.String)
+     */
+    @Override
     public native String getHeader(String name) /*-{
         return this.headers[name];
     }-*/;
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getState()
+     */
+    @Override
     public State getState() {
         return State.fromString(getStateImpl());
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.atmosphere.gwt20.client.ResponseManager#getTransport()
+     */
+    @Override
     public Transport getTransport() {
         return Transport.fromString(getTransportImpl());
     }
-        
-    protected AtmosphereResponse() {
-    }
-    
-    native void setMessageObject(Object message) /*-{
+
+    @Override
+    public native void setMessageObject(Object message) /*-{
         this.messageObject = message;
     }-*/;
-    
+
+    protected AtmosphereResponse() {
+    }
+
     native Object getMessageObject() /*-{
         return this.messageObject;
     }-*/;
-    
+
     private native String getStateImpl() /*-{
         return this.state;
     }-*/;
@@ -114,5 +138,5 @@ public final class AtmosphereResponse extends JavaScriptObject {
     private native String getTransportImpl() /*-{
         return this.transport;
     }-*/;
-    
+
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereServerRequest.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereServerRequest.java
@@ -1,0 +1,16 @@
+package org.atmosphere.gwt20.client;
+
+import com.google.gwt.user.client.rpc.SerializationException;
+
+public interface AtmosphereServerRequest
+{
+    void push(Object message) throws SerializationException;
+
+    void pushImpl(String message);
+
+    void pushLocal(Object message) throws SerializationException;
+
+    void pushLocalImpl(String message);
+
+    String getUUID();
+}

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereServerResponse.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereServerResponse.java
@@ -1,0 +1,31 @@
+package org.atmosphere.gwt20.client;
+
+import java.util.List;
+
+import org.atmosphere.gwt20.client.AtmosphereResponse.State;
+import org.atmosphere.gwt20.client.RequestConfig.Transport;
+
+public interface AtmosphereServerResponse
+{
+    /**
+     * See com.google.gwt.http.client.Response for status codes
+     *
+     * @return
+     */
+    int getStatus();
+
+    String getReasonPhrase() ;
+
+    <T> List<T> getMessages();
+
+    String getResponseBody();
+
+    String getHeader(String name);
+
+    State getState();
+
+    Transport getTransport();
+
+    void setMessageObject(Object inMessage);
+
+}

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereSubscriber.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereSubscriber.java
@@ -1,0 +1,7 @@
+package org.atmosphere.gwt20.client;
+
+public interface AtmosphereSubscriber
+{
+    AtmosphereServerRequest subscribe(RequestConfig requestConfig);
+    void unsubscribe();
+}

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereTransportFailureHandler.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereTransportFailureHandler.java
@@ -20,5 +20,5 @@ package org.atmosphere.gwt20.client;
  * @author jotec
  */
 public interface AtmosphereTransportFailureHandler {
-    public void onTransportFailure(String errorMsg, AtmosphereRequest request);
+    public void onTransportFailure(String errorMsg, AtmosphereServerRequest request);
 }

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/RequestConfig.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/RequestConfig.java
@@ -1,0 +1,108 @@
+package org.atmosphere.gwt20.client;
+
+import com.google.gwt.http.client.RequestBuilder.Method;
+
+public interface RequestConfig
+{
+    public enum Transport {
+        SESSION,
+        LONG_POLLING,
+        STREAMING,
+        JSONP,
+        SSE,
+        WEBSOCKET;
+
+        @Override
+        public String toString() {
+            switch(this) {
+                default:
+                case SESSION: return "session";
+                case LONG_POLLING: return "long-polling";
+                case STREAMING : return "streaming";
+                case JSONP: return "jsonp";
+                case SSE: return "sse";
+                case WEBSOCKET: return "websocket";
+            }
+        }
+
+        public static Transport fromString(String s) {
+            for (Transport t : Transport.values()) {
+                if (t.toString().equals(s)) {
+                    return t;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum Flags {
+        enableXDR,
+        rewriteURL,
+        attachHeadersAsQueryString,
+        withCredentials,
+        trackMessageLength,
+        shared,
+        readResponsesHeaders,
+        dropAtmosphereHeaders,
+        executeCallbackBeforeReconnect,
+        enableProtocol
+    }
+
+    void setFlags(Flags ... flags);
+
+    void clearFlags(Flags ... flags);
+
+    void setOutboundSerializer(ClientSerializer serializer);
+
+    void setHeader(String name, String value);
+
+    void setMaxReconnectOnClose(int maxReconnectOnClose);
+
+    void setContentType(String contentType);
+
+    void setUrl(String url);
+
+    void setConnectTimeout(int connectTimeout);
+
+    void setReconnectInterval(int reconnectInterval);
+
+    void setTimeout(int timeout);
+
+    void setLogLevel(String logLevel);
+
+    void setMaxRequest(int maxRequest);
+
+    void setMaxStreamingLength(int maxStreamingLength);
+
+    void setMethod(Method method);
+
+    void setFallbackMethod(Method method);
+
+    void setTransport(Transport transport);
+
+    void setFallbackTransport(Transport transport);
+
+    void setOpenHandler(AtmosphereOpenHandler handler);
+
+    void setReopenHandler(AtmosphereReopenHandler handler);
+
+    void setCloseHandler(AtmosphereCloseHandler handler);
+
+    void setClientTimeoutHandler(AtmosphereClientTimeoutHandler handler);
+
+    void setMessageHandler(AtmosphereMessageHandler handler);
+
+    void setLocalMessageHandler(AtmosphereMessageHandler handler);
+
+    void setErrorHandler(AtmosphereErrorHandler handler);
+
+    void setReconnectHandler(AtmosphereReconnectHandler handler);
+
+    void setFailureToReconnectHandler(AtmosphereFailureToReconnectHandler handler);
+
+    void setMessagePublishedHandler(AtmosphereMessagePublishedHandler handler);
+
+    void setTransportFailureHandler(AtmosphereTransportFailureHandler handler);
+
+    ClientSerializer getOutboundSerializer();
+}


### PR DESCRIPTION
Currently, testing Atmosphere GWT is very difficult because everything is a concrete implementation with no interface provided.

This commit fixes this problem by providing various new interfaces for Atmosphere, AtmosphereRequest, AtmosphereResponse and AtmosphereRequestConfig.

This avoids a lot JSNI as well.

This should fix issue #127
