### PR TITLE
Wrong heartbeatInterval and timeout sent to client

### DIFF
--- a/socketio/modules/src/main/java/org/atmosphere/socketio/cpr/SocketIOAtmosphereInterceptor.java
+++ b/socketio/modules/src/main/java/org/atmosphere/socketio/cpr/SocketIOAtmosphereInterceptor.java
@@ -146,7 +146,7 @@ public class SocketIOAtmosphereInterceptor implements AtmosphereInterceptor {
                 response.setContentType("plain/text");
                 
                 SocketIOSession session = getSessionManager(version).createSession((AtmosphereResourceImpl) r, atmosphereHandler);
-                response.getWriter().print(session.getSessionId() + ":" + heartbeatInterval + ":" + timeout + ":" + availableTransports);
+                response.getWriter().print(session.getSessionId() + ":" + (heartbeatInterval/1000) + ":" + (timeout/1000) + ":" + availableTransports);
 
                 return Action.CANCELLED;
             } else if (protocol != null && version == null) {


### PR DESCRIPTION
The socketio client is waiting for heartbeat and timeout values in second units but this interceptor sends them in milliseconds.
Behaviour corrected by dividing by 1000.
