### PR TITLE
Fix #150

### DIFF
--- a/rmi/modules/src/main/java/org/atmosphere/plugin/rmi/RMIBroadcaster.java
+++ b/rmi/modules/src/main/java/org/atmosphere/plugin/rmi/RMIBroadcaster.java
@@ -66,7 +66,7 @@ public class RMIBroadcaster extends AbstractBroadcasterProxy {
     public void incomingBroadcast() {
         try {
             logger.info("Starting Atmosphere RMI Clustering support");
-            RMIPeerManager.getInstance().server(getID(), new RMIBroadcastServiceImpl(this));
+            RMIPeerManager.getInstance().server(getID(), new RMIBroadcastServiceImpl(this), config);
         } catch (Throwable t) {
             logger.warn("Failed to initialize RMI server", t);
         } finally {

--- a/rmi/modules/src/test/java/org/atmosphere/plugin/rmi/test/RMIPluginTest.java
+++ b/rmi/modules/src/test/java/org/atmosphere/plugin/rmi/test/RMIPluginTest.java
@@ -96,7 +96,7 @@ public class RMIPluginTest {
 
         // Bind on mocked service on port 4000
         final RMIBroadcastService service = new RMIBroadcastServiceImpl(broadcaster);
-        RMIPeerManager.getInstance().server("RMITopic", service);
+        RMIPeerManager.getInstance().server("RMITopic", service, null);
 
         // Send message
         final String url = String.format("rmi://localhost:4000/%s/RMITopic", RMIBroadcastService.class.getSimpleName());


### PR DESCRIPTION
This is a dirty hack. I think a best implementation for ShutdownHook look like this:

```
try {
    registry.unbind(url);
    if (service instanceof UnicastRemoteObject) {
        UnicastRemoteObject.unexportObject(service, true);
    }
    } catch (RemoteException e) {
        logger.error("Unable to unexport RMI service", e);
    } catch (NotBoundException e) {
        logger.error("Unable to unbind RMI url", e);
}
```

But this is not work and i don't know why.
Look http://stackoverflow.com/questions/7386227/jvm-wont-terminate
