### PR TITLE
Remove @RequestScoped from AtmosphereJerseyServletModule

### DIFF
--- a/guice/modules/src/main/java/org/atmosphere/guice/AtmosphereJerseyServletModule.java
+++ b/guice/modules/src/main/java/org/atmosphere/guice/AtmosphereJerseyServletModule.java
@@ -40,7 +40,6 @@
 package org.atmosphere.guice;
 
 import com.google.inject.Provides;
-import com.google.inject.servlet.RequestScoped;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.api.core.ExtendedUriInfo;
 import com.sun.jersey.api.core.HttpContext;
@@ -109,49 +108,41 @@ public class AtmosphereJerseyServletModule extends ServletModule {
         return webApplication.getExceptionMapperContext();
     }
 
-    @RequestScoped
     @Provides
     public HttpContext httpContext(WebApplication webApplication) {
         return webApplication.getThreadLocalHttpContext();
     }
 
     @Provides
-    @RequestScoped
     public UriInfo uriInfo(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getUriInfo();
     }
 
     @Provides
-    @RequestScoped
     public ExtendedUriInfo extendedUriInfo(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getUriInfo();
     }
 
-    @RequestScoped
     @Provides
     public HttpRequestContext requestContext(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getRequest();
     }
 
-    @RequestScoped
     @Provides
     public HttpHeaders httpHeaders(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getRequest();
     }
 
-    @RequestScoped
     @Provides
     public Request request(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getRequest();
     }
 
-    @RequestScoped
     @Provides
     public SecurityContext securityContext(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getRequest();
     }
 
-    @RequestScoped
     @Provides
     public HttpResponseContext responseContext(WebApplication wa) {
         return wa.getThreadLocalHttpContext().getResponse();


### PR DESCRIPTION
This patch removes `@RequestScoped` annotations from
`AtmosphereJerseyServletModule` to avoid the following errors:

```
2014.06.20 11:37:53.219 ERROR [] ThrowableMapper -  Encountered uncaught exception:
com.google.inject.ProvisionException: Guice provision errors:

1) Error in custom provider, com.google.inject.OutOfScopeException:
Cannot access scoped object. Either we are not currently inside an HTTP
Servlet request, or you may have forgotten to apply
com.google.inject.servlet.GuiceFilter as a servlet filter for this
request.
...
```

---

Hi @jfarcand,

Thanks for merging my previous patch. I'd like to add some modifications on the patch because I got the following errors. It worked perfectly after I applied this patch.

```
2014.06.20 11:37:53.219 ERROR [] ThrowableMapper -  Encountered uncaught exception:
com.google.inject.ProvisionException: Guice provision errors:

1) Error in custom provider, com.google.inject.OutOfScopeException:
Cannot access scoped object. Either we are not currently inside an HTTP
Servlet request, or you may have forgotten to apply
com.google.inject.servlet.GuiceFilter as a servlet filter for this
request.
  at
  com.example.api.servlet.AtmosphereJerseyServletModule.securityContext(AtmosphereJerseyServletModule.java:155)
  while locating javax.ws.rs.core.SecurityContext
    for parameter 2 at
    com.example.api.rest_api.ApplicationResource.<init>(ApplicationResource.java:61)
  while locating com.example.api.rest_api.ApplicationResource
  Caused by: com.google.inject.OutOfScopeException: Cannot
  access scoped object. Either we are not currently inside an
  HTTP Servlet request, or you may have forgotten to apply
  com.google.inject.servlet.GuiceFilter as a servlet filter for
  this request.
        at
        com.google.inject.servlet.GuiceFilter.getContext(GuiceFilter.java:135)
        at
        com.google.inject.servlet.GuiceFilter.getRequest(GuiceFilter.java:121)
        at
        com.google.inject.servlet.ServletScopes$1$1.get(ServletScopes.java:78)
        at
        com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:40)
        at
        com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
        at
        com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
        at
        com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:84)
        at
        com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:254)
        at
        com.google.inject.internal.InjectorImpl$4$1.call(InjectorImpl.java:978)
        at
        com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1024)
        at
        com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:974)
        at
        com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1013)
        at
        com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory$GuiceInstantiatedComponentProvider.getInstance(GuiceComponentProviderFactory.java:332)
        at
        com.sun.jersey.server.impl.component.IoCResourceFactory$PerRequestWrapper.getInstance(IoCResourceFactory.java:150)
        at
        com.sun.jersey.server.impl.application.WebApplicationContext.getResource(WebApplicationContext.java:238)
        at
        com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:83)
        at
        com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
        at
        com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1469)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1400)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1349)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1339)
        at
        com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:537)
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:708)
        at
        javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
        at
        org.atmosphere.util.AtmosphereFilterChain.doFilter(AtmosphereFilterChain.java:135)
        at
        org.atmosphere.util.AtmosphereFilterChain.invokeFilterChain(AtmosphereFilterChain.java:96)
        at
        org.atmosphere.handler.ReflectorServletProcessor$FilterChainServletWrapper.service(ReflectorServletProcessor.java:320)
        at
        org.atmosphere.handler.ReflectorServletProcessor.onRequest(ReflectorServletProcessor.java:163)
        at
        org.atmosphere.cpr.AsynchronousProcessor.action(AsynchronousProcessor.java:174)
        at
        org.atmosphere.cpr.AsynchronousProcessor.suspended(AsynchronousProcessor.java:95)
        at
        org.atmosphere.container.JettyWebSocketUtil.doService(JettyWebSocketUtil.java:70)
        at
        org.atmosphere.container.JettyAsyncSupportWithWebSocket.service(JettyAsyncSupportWithWebSocket.java:66)
        at
        org.atmosphere.cpr.AtmosphereFramework.doCometSupport(AtmosphereFramework.java:1801)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:434)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor$2.run(DefaultWebSocketProcessor.java:287)
        at
        org.atmosphere.util.VoidExecutorService.execute(VoidExecutorService.java:101)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:281)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.invokeWebSocketProtocol(DefaultWebSocketProcessor.java:305)
        at
        org.atmosphere.container.JettyWebSocketHandler.onMessage(JettyWebSocketHandler.java:97)
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455$WSFrameHandler.onFrame(WebSocketConnectionRFC6455.java:845)
        at
        org.eclipse.jetty.websocket.WebSocketParserRFC6455.parseNext(WebSocketParserRFC6455.java:359)
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455.handle(WebSocketConnectionRFC6455.java:235)
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:622)
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:46)
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:603)
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:538)
        at java.lang.Thread.run(Thread.java:744)

2) Error in custom provider,
com.google.inject.OutOfScopeException: Cannot access scoped
object. Either we are not currently inside an HTTP Servlet
request, or you may have forgotten to apply
com.google.inject.servlet.GuiceFilter as a servlet filter for
this request.
  at
  com.example.api.servlet.AtmosphereJerseyServletModule.uriInfo(AtmosphereJerseyServletModule.java:125)
  while locating javax.ws.rs.core.UriInfo
    for parameter 1 at
    com.example.api.rest_api.ApplicationResource.<init>(ApplicationResource.java:61)
  while locating com.example.api.rest_api.ApplicationResource
  Caused by: com.google.inject.OutOfScopeException: Cannot
  access scoped object. Either we are not currently inside an
  HTTP Servlet request, or you may have forgotten to apply
  com.google.inject.servlet.GuiceFilter as a servlet filter for
  this request.
        at
        com.google.inject.servlet.GuiceFilter.getContext(GuiceFilter.java:135)
        at
        com.google.inject.servlet.GuiceFilter.getRequest(GuiceFilter.java:121)
        at
        com.google.inject.servlet.ServletScopes$1$1.get(ServletScopes.java:78)
        at
        com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:40)
        at
        com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
        at
        com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
        at
        com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:84)
        at
        com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:254)
        at
        com.google.inject.internal.InjectorImpl$4$1.call(InjectorImpl.java:978)
        at
        com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1024)
        at
        com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:974)
        at
        com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1013)
        at
        com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory$GuiceInstantiatedComponentProvider.getInstance(GuiceComponentProviderFactory.java:332)
        at
        com.sun.jersey.server.impl.component.IoCResourceFactory$PerRequestWrapper.getInstance(IoCResourceFactory.java:150)
        at
        com.sun.jersey.server.impl.application.WebApplicationContext.getResource(WebApplicationContext.java:238)
        at
        com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:83)
        at
        com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
        at
        com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1469)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1400)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1349)
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1339)
        at
        com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:537)
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:708)
        at
        javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
        at
        org.atmosphere.util.AtmosphereFilterChain.doFilter(AtmosphereFilterChain.java:135)
        at
        org.atmosphere.util.AtmosphereFilterChain.invokeFilterChain(AtmosphereFilterChain.java:96)
        at
        org.atmosphere.handler.ReflectorServletProcessor$FilterChainServletWrapper.service(ReflectorServletProcessor.java:320)
        at
        org.atmosphere.handler.ReflectorServletProcessor.onRequest(ReflectorServletProcessor.java:163)
        at
        org.atmosphere.cpr.AsynchronousProcessor.action(AsynchronousProcessor.java:174)
        at
        org.atmosphere.cpr.AsynchronousProcessor.suspended(AsynchronousProcessor.java:95)
        at
        org.atmosphere.container.JettyWebSocketUtil.doService(JettyWebSocketUtil.java:70)
        at
        org.atmosphere.container.JettyAsyncSupportWithWebSocket.service(JettyAsyncSupportWithWebSocket.java:66)
        at
        org.atmosphere.cpr.AtmosphereFramework.doCometSupport(AtmosphereFramework.java:1801)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:434)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor$2.run(DefaultWebSocketProcessor.java:287)
        at
        org.atmosphere.util.VoidExecutorService.execute(VoidExecutorService.java:101)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:281)
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.invokeWebSocketProtocol(DefaultWebSocketProcessor.java:305)
        at
        org.atmosphere.container.JettyWebSocketHandler.onMessage(JettyWebSocketHandler.java:97)
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455$WSFrameHandler.onFrame(WebSocketConnectionRFC6455.java:845)
        at
        org.eclipse.jetty.websocket.WebSocketParserRFC6455.parseNext(WebSocketParserRFC6455.java:359)
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455.handle(WebSocketConnectionRFC6455.java:235)
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:622)
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:46)
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:603)
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:538)
        at java.lang.Thread.run(Thread.java:744)

2 errors
        at
        com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:987)
~[guice-3.0.jar:na]
        at
        com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1013)
~[guice-3.0.jar:na]
        at
        com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory$GuiceInstantiatedComponentProvider.getInstance(GuiceComponentProviderFactory.java:332)
~[jersey-guice-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.component.IoCResourceFactory$PerRequestWrapper.getInstance(IoCResourceFactory.java:150)
~[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.application.WebApplicationContext.getResource(WebApplicationContext.java:238)
~[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:83)
~[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
~[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
~[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1469)
[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1400)
[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1349)
[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1339)
[jersey-server-1.10.jar:1.10]
        at
        com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
[jersey-servlet-1.10.jar:1.10]
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:537)
[jersey-servlet-1.10.jar:1.10]
        at
        com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:708)
[jersey-servlet-1.10.jar:1.10]
        at
        javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
[javax.servlet-3.0.0.v201112011016.jar:na]
        at
        org.atmosphere.util.AtmosphereFilterChain.doFilter(AtmosphereFilterChain.java:135)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.util.AtmosphereFilterChain.invokeFilterChain(AtmosphereFilterChain.java:96)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.handler.ReflectorServletProcessor$FilterChainServletWrapper.service(ReflectorServletProcessor.java:320)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.handler.ReflectorServletProcessor.onRequest(ReflectorServletProcessor.java:163)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.cpr.AsynchronousProcessor.action(AsynchronousProcessor.java:174)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.cpr.AsynchronousProcessor.suspended(AsynchronousProcessor.java:95)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.container.JettyWebSocketUtil.doService(JettyWebSocketUtil.java:70)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.container.JettyAsyncSupportWithWebSocket.service(JettyAsyncSupportWithWebSocket.java:66)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.cpr.AtmosphereFramework.doCometSupport(AtmosphereFramework.java:1801)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:434)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor$2.run(DefaultWebSocketProcessor.java:287)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.util.VoidExecutorService.execute(VoidExecutorService.java:101)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:281)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.websocket.DefaultWebSocketProcessor.invokeWebSocketProtocol(DefaultWebSocketProcessor.java:305)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.atmosphere.container.JettyWebSocketHandler.onMessage(JettyWebSocketHandler.java:97)
[atmosphere-runtime-2.1.4.jar:2.1.4]
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455$WSFrameHandler.onFrame(WebSocketConnectionRFC6455.java:845)
[jetty-websocket-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.websocket.WebSocketParserRFC6455.parseNext(WebSocketParserRFC6455.java:359)
[jetty-websocket-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.websocket.WebSocketConnectionRFC6455.handle(WebSocketConnectionRFC6455.java:235)
[jetty-websocket-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:622)
[jetty-io-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:46)
[jetty-io-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:603)
[jetty-util-8.1.5.v20120716.jar:8.1.5.v20120716]
        at
        org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:538)
[jetty-util-8.1.5.v20120716.jar:8.1.5.v20120716]
        at java.lang.Thread.run(Thread.java:744) [na:1.7.0_45]
```
