### PR TITLE
Switching class loader approach in atmosphere-gwt20

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-common/src/main/java/org/atmosphere/gwt20/server/GwtRpcUtil.java
+++ b/gwt20/modules/atmosphere-gwt20-common/src/main/java/org/atmosphere/gwt20/server/GwtRpcUtil.java
@@ -192,7 +192,7 @@ public class GwtRpcUtil implements ServerSerializerProvider {
     }
 
     public static Object deserialize(String data) throws SerializationException {
-        ServerSerializationStreamReader reader = new ServerSerializationStreamReader(GwtRpcUtil.class.getClassLoader(), GwtRpcUtil.getSerializationPolicyProvider());
+        ServerSerializationStreamReader reader = new ServerSerializationStreamReader(Thread.currentThread().getContextClassLoader(), GwtRpcUtil.getSerializationPolicyProvider());
         reader.prepareToRead(data);
         return reader.readObject();
     }


### PR DESCRIPTION
Would like to propose we use the context class loader instead of the class loader of the atmosphere-gwt20-common jar in order to support running in environments with more carefully managed class loaders (such as an OSGi container).
