### PR TITLE
Update AtmosphereGwt20.gwt.xml

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-client/src/main/resources/org/atmosphere/gwt20/AtmosphereGwt20.gwt.xml
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/resources/org/atmosphere/gwt20/AtmosphereGwt20.gwt.xml
@@ -13,7 +13,6 @@
 <!-- limitations under the License.                                         -->
 <module rename-to="atmosphere_gwt20">
     <inherits name="com.google.gwt.user.User"/>
-    <inherits name="com.google.gwt.rpc.RPC"/>
     <inherits name="com.google.web.bindery.autobean.AutoBean"/>
     <inherits name='org.atmosphere.gwt20.Common' />
 


### PR DESCRIPTION
Removed inherit of the deRPC module file as deRPC was always an experimental feature and has been removed from GWT 2.7, the code does not appear to be using any deRPC features so the suspicion is that the module file was included accidentally.
