### PR TITLE
Created HazlecastInterceptor that posts the messages onto the same topic

### DIFF
--- a/hazelcast/modules/pom.xml
+++ b/hazelcast/modules/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.1.1</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastInterceptor.java
+++ b/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/HazelcastInterceptor.java
@@ -1,0 +1,46 @@
+package org.atmosphere.plugin.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import org.atmosphere.cpr.Action;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereInterceptorAdapter;
+import org.atmosphere.cpr.AtmosphereResource;
+
+public class HazelcastInterceptor extends AtmosphereInterceptorAdapter {
+
+    private static HazelcastInstance HAZELCAST_INSTANCE;
+
+    @Override
+    public void configure(AtmosphereConfig config) {
+        // this can be added to properties file or some place to be configured
+        System.setProperty("hazelcast.event.queue.capacity", "10000000000"); 
+        System.setProperty("hazelcast.event.thread.count", "5");
+
+        HAZELCAST_INSTANCE = Hazelcast.newHazelcastInstance();
+        HAZELCAST_INSTANCE.getTopic("distributeMessages").addMessageListener(new MessageListener<Object>() {
+            @Override
+            public void onMessage(Message<Object> inMessage) {
+                if (!inMessage.getPublishingMember().localMember()) {
+                    if (inMessage.getMessageObject() instanceof TopicMessage) {
+                        TopicMessage topicMessage = (TopicMessage) inMessage.getMessageObject();
+                        String message = topicMessage.getMessage();
+                        /// Do code as you would normaly here
+
+                    }
+                }
+            }
+        });
+        super.configure(config);
+    }
+
+    @Override
+    public Action inspect(AtmosphereResource resource) {
+        if (!resource.getRequest().body().isEmpty()) {
+            HAZELCAST_INSTANCE.getTopic("distributeMessages").publish(new TopicMessage(resource.getRequest().headersMap(), resource.getBroadcaster().getID(), resource.getRequest().body().asString()));
+        }
+        return Action.CONTINUE;
+    }
+}

--- a/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/TopicMessage.java
+++ b/hazelcast/modules/src/main/java/org/atmosphere/plugin/hazelcast/TopicMessage.java
@@ -1,0 +1,42 @@
+package org.atmosphere.plugin.hazelcast;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class TopicMessage implements Serializable {
+
+    private Map<String, String> headers;
+    private String broadcasterId;
+    private String message;
+
+    public TopicMessage( Map<String, String> headers, String broadcasterId, String message) {
+        this.headers = headers;
+        this.broadcasterId = broadcasterId;
+        this.message = message;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public String getBroadcasterId() {
+        return broadcasterId;
+    }
+
+    public void setBroadcasterId(String broadcasterId) {
+        this.broadcasterId = broadcasterId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}


### PR DESCRIPTION
Created HazlecastInterceptor that posts the messages onto the same topic on all server. Then after receiving the message from a different server, I follow the same route as I did when receiving a normal message. This will work better then the HazelcastBroadcaster when using MetaBroadcaster methods.

scenario 1: Using the MetaBroadcaster  and HazelcastBroadcaster:
Architecture: Two Atmosphere servers with Hazelcast and a Load balancer.
Client 1 connected to server one. ("myConnections/client1")
Client 2 connected to server two using meta broadcaster to send to /* broadcasters. ("myConnections/broadcastAll")

```
metaBroadcaster.broadcastTo("myConnections/*", message);

```

 * If broadcasters does not exist on server two, then the message will never be added to the Hazelcast Topic and thus never be received by client 1 on server 1.