### PR TITLE
Updated rabbitmq java client to latest version

### DIFF
--- a/rabbitmq/modules/pom.xml
+++ b/rabbitmq/modules/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
           <groupId>com.rabbitmq</groupId>
           <artifactId>amqp-client</artifactId>
-          <version>3.1.1</version>
+          <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
3.1.1 Is almost two years old, a lot of bugfixes have been made so upgrading to 3.5.0 is recommended.