### PR TITLE
Added reconnectOnServerError flag in AtmosphereRequestConfig

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
@@ -77,7 +77,8 @@ public final class AtmosphereRequestConfig extends JavaScriptObject implements R
         readResponsesHeaders,
         dropAtmosphereHeaders,
         executeCallbackBeforeReconnect,
-        enableProtocol
+        enableProtocol,
+        reconnectOnServerError
     }
     /**
      * use the same serializer for inbound and outbound


### PR DESCRIPTION
Provides the ability to set and clear the reconnectOnServerError request attribute with the AtmosphereRequestConfig.