### PR TITLE
default bootstrap server should be local

### DIFF
--- a/kafka/modules/src/main/java/org/atmosphere/kafka/KafkaBroadcaster.java
+++ b/kafka/modules/src/main/java/org/atmosphere/kafka/KafkaBroadcaster.java
@@ -73,7 +73,7 @@ public class KafkaBroadcaster extends AbstractBroadcasterProxy {
             String load = config.getInitParameter(PROPERTIES_FILE, null);
             Properties props = new Properties();
             if (load == null) {
-                props.put("bootstrap.servers", "10.0.1.10:9092");
+                props.put("bootstrap.servers", "127.0.0.1:9092");
                 props.put("zk.connect", "127.0.0.1:9092");
                 props.put("group.id", "kafka.atmosphere");
                 props.put("partition.assignment.strategy", "roundrobin");


### PR DESCRIPTION
It makes more sense to default to a local kafka instance instead of one running on `10.0.1.10`.