### PR TITLE
revert last commit.

### DIFF
--- a/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringContext.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringContext.java
@@ -15,17 +15,12 @@
  */
 package org.atmosphere.spring.bean;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
-
-import org.atmosphere.util.ServletProxyFactory;
 
 /**
  * Spring context.
@@ -35,6 +30,17 @@ import org.atmosphere.util.ServletProxyFactory;
 public class AtmosphereSpringContext implements ServletConfig {
 
     private Map<String, String> config;
+    
+    private ServletContext servletContext;
+
+	@Override
+	public ServletContext getServletContext() {
+		return servletContext;
+	}
+
+	public void setServletContext(ServletContext servletContext) {
+		this.servletContext = servletContext;
+	}
 
     @Override
     public String getServletName() {
@@ -42,16 +48,6 @@ public class AtmosphereSpringContext implements ServletConfig {
     }
 
     @Override
-	public ServletContext getServletContext() {
-		return (ServletContext) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { ServletContext.class }, new InvocationHandler() {
-			@Override
-			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-				return ServletProxyFactory.getDefault().proxy(proxy, method, args);
-			}
-		});
-	}
-
-	@Override
     public String getInitParameter(String s) {
         return config.get(s);
     }

--- a/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringContext.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringContext.java
@@ -15,12 +15,17 @@
  */
 package org.atmosphere.spring.bean;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
+
+import org.atmosphere.util.ServletProxyFactory;
 
 /**
  * Spring context.
@@ -30,17 +35,6 @@ import javax.servlet.ServletContext;
 public class AtmosphereSpringContext implements ServletConfig {
 
     private Map<String, String> config;
-    
-    private ServletContext servletContext;
-
-	@Override
-	public ServletContext getServletContext() {
-		return servletContext;
-	}
-
-	public void setServletContext(ServletContext servletContext) {
-		this.servletContext = servletContext;
-	}
 
     @Override
     public String getServletName() {
@@ -48,6 +42,16 @@ public class AtmosphereSpringContext implements ServletConfig {
     }
 
     @Override
+	public ServletContext getServletContext() {
+		return (ServletContext) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { ServletContext.class }, new InvocationHandler() {
+			@Override
+			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+				return ServletProxyFactory.getDefault().proxy(proxy, method, args);
+			}
+		});
+	}
+
+	@Override
     public String getInitParameter(String s) {
         return config.get(s);
     }

--- a/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringServlet.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringServlet.java
@@ -15,18 +15,19 @@
  */
 package org.atmosphere.spring.bean;
 
-import org.atmosphere.cpr.AtmosphereFramework;
-import org.atmosphere.cpr.AtmosphereRequestImpl;
-import org.atmosphere.cpr.AtmosphereResponseImpl;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import java.io.IOException;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import org.atmosphere.cpr.AtmosphereFramework;
+import org.atmosphere.cpr.AtmosphereRequestImpl;
+import org.atmosphere.cpr.AtmosphereResponseImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 /**
  * Spring Atmosphere's Servlet.
@@ -35,63 +36,53 @@ import java.io.IOException;
  */
 public class AtmosphereSpringServlet extends HttpServlet {
 
-    private static final long serialVersionUID = 6755906261738522768L;
+	private static final long serialVersionUID = 6755906261738522768L;
 
-    @Autowired
-    private AtmosphereFramework framework;
-    
-    @Autowired
-	private AtmosphereSpringContext atmosphereSpringContext;
+	@Autowired
+	private AtmosphereFramework framework;
 
-    @Override
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
-        
-     	WebApplicationContextUtils.
-                getRequiredWebApplicationContext(getServletContext()).
-                getAutowireCapableBeanFactory().
-                autowireBean(this);
-     	
-        // set the real servlet context
-        atmosphereSpringContext.setServletContext(config.getServletContext());
-     	framework.init(atmosphereSpringContext, false);
+	@Override
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-    }
+		WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext()).getAutowireCapableBeanFactory()
+				.autowireBean(this);
 
-    @Override
-    public void doHead(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	}
 
-    @Override
-    public void doOptions(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	@Override
+	public void doHead(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
 
-    @Override
-    public void doTrace(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	@Override
+	public void doOptions(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
 
-    @Override
-    public void doDelete(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	@Override
+	public void doTrace(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
 
-    @Override
-    public void doPut(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	@Override
+	public void doDelete(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
 
-    @Override
-    public void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
-        doPost(req, res);
-    }
+	@Override
+	public void doPut(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
 
-    @Override
-    public void doPost(HttpServletRequest req, HttpServletResponse res)
-            throws IOException, ServletException {
-        framework.doCometSupport(AtmosphereRequestImpl.wrap(req), AtmosphereResponseImpl.wrap(res));
-    }
+	@Override
+	public void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		doPost(req, res);
+	}
+
+	@Override
+	public void doPost(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+		framework.doCometSupport(AtmosphereRequestImpl.wrap(req), AtmosphereResponseImpl.wrap(res));
+	}
 
 }

--- a/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringServlet.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/bean/AtmosphereSpringServlet.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2015 Async-IO.org
- *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -45,8 +42,10 @@ public class AtmosphereSpringServlet extends HttpServlet {
 	public void init(ServletConfig config) throws ServletException {
 		super.init(config);
 
-		WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext()).getAutowireCapableBeanFactory()
-				.autowireBean(this);
+		WebApplicationContextUtils.		 	
+	         	getRequiredWebApplicationContext(getServletContext()).		 
+	            getAutowireCapableBeanFactory().		 
+	            autowireBean(this);
 
 	}
 


### PR DESCRIPTION
Calling framework.init() from AtmosphereSpringServlet.init() is too
late.
Eg:
atmosphereFramework().getAtmosphereConfig().getBroadcasterFactory() gets
called before framework.init, which means things like broadcasterTypes
are empty which is not good. I was trying to install the JMSBroadcaster,
and it doesn't work because of this bug.