### PR TITLE
Add support for Spring 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
         <felix-version>2.3.6</felix-version>
         <jms-version>1.1-rev-1</jms-version>
         <guice-version>3.0</guice-version>
-        <spring-version>4.1.3.RELEASE</spring-version>
+        <spring-version>3.2.16.RELEASE</spring-version>
         <wicket.version>1.4.12</wicket.version>
         <ahc.version>1.8.3</ahc.version>
         <jedis.version>2.0.0</jedis.version>

--- a/spring/modules/src/main/java/org/atmosphere/spring/SpringWebObjectFactory.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/SpringWebObjectFactory.java
@@ -87,7 +87,7 @@ public class SpringWebObjectFactory implements AtmosphereObjectFactory<Class<?>>
 
             // Hack to make it injectable
             context.register(AtmosphereConfig.class);
-            context.getBean(AtmosphereConfig.class, config.framework()).populate(config);
+            ((AtmosphereConfig) context.getBean(AtmosphereConfig.class.getCanonicalName(), config.framework())).populate(config);
         } catch (Exception ex) {
             logger.warn("Unable to configure injection", ex);
         }


### PR DESCRIPTION
atmosphere-spring brings support for Spring 4.

With the current code, it is almost impossible to integrate atmosphere-spring into a Spring 3 project due to a [missing method](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/BeanFactory.html#getBean-java.lang.Class-java.lang.Object...-)  in `BeanFactory` (i.e. `ApplicationContext`) which was added in Spring 4.1: `<T> T getBean(Class<T> requiredType, Object... args) throws BeansException;`

This PR replaces the use of `T getBean(Class<T> requiredType, Object... args)` by `Object getBean(String name, Object... args)`, which has been around since Spring 2.5. This way, you can also use atmosphere-spring with older Spring versions.

Changing the property `spring-version` to 3.2.x is not mandatory but might help to assert future changes won't break compatibility with Spring 3.