### PR TITLE
removed method AutoBeanClientSerializer#registerBeanFactory(Class<Aut…

### DIFF
--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AutoBeanClientSerializer.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AutoBeanClientSerializer.java
@@ -31,7 +31,6 @@
 
 package org.atmosphere.gwt20.client;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.web.bindery.autobean.shared.AutoBean;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
@@ -80,10 +79,6 @@ public class AutoBeanClientSerializer implements ClientSerializer {
     private Class<Object> activeBeanClass;
     // buffer in order to capture split messages
     private StringBuffer buffer = new StringBuffer(16100);
-
-    public void registerBeanFactory(Class<AutoBeanFactory> factoryClass, Class forBean) {
-        registerBeanFactory((AutoBeanFactory) GWT.create(factoryClass), forBean);
-    }
 
     public void registerBeanFactory(AutoBeanFactory factory, Class forBean) {
         if (beanFactories == null) {


### PR DESCRIPTION
…oBeanFactory> factoryClass, Class forBean)

see
  https://github.com/Atmosphere/atmosphere-extensions/issues/169
  https://github.com/Atmosphere/atmosphere-extensions/issues/194
  https://github.com/Atmosphere/atmosphere-extensions/issues/216