### PR TITLE
Fix Spring 5 integration

### DIFF
--- a/spring/modules/src/main/java/org/atmosphere/spring/SpringWebObjectFactory.java
+++ b/spring/modules/src/main/java/org/atmosphere/spring/SpringWebObjectFactory.java
@@ -87,7 +87,9 @@ public class SpringWebObjectFactory implements AtmosphereObjectFactory<Class<?>>
 
             // Hack to make it injectable
             context.register(AtmosphereConfig.class);
-            ((AtmosphereConfig) context.getBean(AtmosphereConfig.class.getCanonicalName(), config.framework())).populate(config);
+            String string = AtmosphereConfig.class.getSimpleName();
+            String beanName = string.substring(0, 1).toLowerCase() + string.substring(1);
+            ((AtmosphereConfig) context.getBean(beanName, config.framework())).populate(config);
         } catch (Exception ex) {
             logger.warn("Unable to configure injection", ex);
         }


### PR DESCRIPTION
I upgraded to the latest of all Atmosphere Jar files and extensions.
I had the following issue with Spring 5.

org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'org.atmosphere.cpr.AtmosphereConfig' available

I have changed the method and checked that it is supported by Spring 3, 4, 5,

spring 3
https://docs.spring.io/autorepo/docs/spring-framework/3.2.3.RELEASE/javadoc-api/org/springframework/context/support/AbstractApplicationContext.html#getBean(java.lang.String,%20java.lang.Object...)

Spring 4 
https://docs.spring.io/autorepo/docs/spring/4.3.2.BUILD-SNAPSHOT/javadoc-api/org/springframework/context/support/AbstractApplicationContext.html#getBean-java.lang.String-java.lang.Object...-

Spring 5 
https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/support/AbstractApplicationContext.html#getBean-java.lang.String-java.lang.Object...-

This fix the error log printout on startup of the application.