### PR TITLE
fix for CDI within EAR

### DIFF
--- a/cdi/modules/src/main/java/org/atmosphere/cdi/CDIObjectFactory.java
+++ b/cdi/modules/src/main/java/org/atmosphere/cdi/CDIObjectFactory.java
@@ -47,14 +47,9 @@ public class CDIObjectFactory implements AtmosphereObjectFactory<Object> {
                 bm = (BeanManager) new InitialContext().lookup("java:comp/env/BeanManager");
             } catch (NamingException e) {
                 logger.error("{}", e);
+                throw new IllegalStateException();
             }
         }
-
-        final Iterator<Bean<?>> i = bm.getBeans(AtmosphereProducers.class).iterator();
-        if (!i.hasNext()) {
-            throw new IllegalStateException();
-        }
-
     }
 
     @Override


### PR DESCRIPTION
The AtmosphereProducers lookup test for somehow reason fails within an EAR deployment on JBoss EAP 6.4.22. Removing it resolves the issue. This test is also kind of pointless. Once you can get a hold to the BeanManager, you know that you live within a CDI environment anyway.