### PR TITLE
AP-62109 Investigate LOE to patch atmosphere-gwt20-client 

### DIFF
--- a/cdi/modules/pom.xml
+++ b/cdi/modules/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-cdi</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-cdi</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
 

--- a/cometd/modules/pom.xml
+++ b/cometd/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-cometd</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-cometd</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/guice/modules/pom.xml
+++ b/guice/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-guice</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-guice</name>
     <url>http://maven.apache.org</url>
     <dependencies>

--- a/guice/modules/src/test/java/org/atmosphere/tests/guice/GuiceConfig.java
+++ b/guice/modules/src/test/java/org/atmosphere/tests/guice/GuiceConfig.java
@@ -85,6 +85,7 @@ public class GuiceConfig extends GuiceServletContextListener {
                     {
                         put(ApplicationConfig.PROPERTY_COMET_SUPPORT, Jetty7CometSupport.class.getName());
                         put(ApplicationConfig.OBJECT_FACTORY, GuiceObjectFactory.class.getName());
+                        put(ApplicationConfig.ANALYTICS, "false");
                         put("org.atmosphere.useNative", "true");
                         put(ApplicationConfig.ANNOTATION_PACKAGE, Resource.class.getPackage().getName());
                     }

--- a/guice/modules/src/test/java/org/atmosphere/tests/guice/jersey/GuiceContextListener.java
+++ b/guice/modules/src/test/java/org/atmosphere/tests/guice/jersey/GuiceContextListener.java
@@ -44,6 +44,7 @@ public final class GuiceContextListener extends GuiceServletContextListener {
                     {
                         put(ApplicationConfig.PROPERTY_COMET_SUPPORT, Jetty7CometSupport.class.getName());
                         put(ApplicationConfig.OBJECT_FACTORY, GuiceObjectFactory.class.getName());
+                        put(ApplicationConfig.ANALYTICS, "false");
                         put("org.atmosphere.useNative", "true");
                         put("com.sun.jersey.config.property.packages", PubSubTest.class.getPackage().getName());
                     }

--- a/gwt20/modules/atmosphere-gwt20-client/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
+++ b/gwt20/modules/atmosphere-gwt20-client/src/main/java/org/atmosphere/gwt20/client/AtmosphereRequestConfig.java
@@ -81,7 +81,8 @@ public final class AtmosphereRequestConfig extends JavaScriptObject implements R
         dropAtmosphereHeaders,
         executeCallbackBeforeReconnect,
         enableProtocol,
-        reconnectOnServerError
+        reconnectOnServerError,
+        closeAsync
     }
     /**
      * use the same serializer for inbound and outbound

--- a/gwt20/modules/atmosphere-gwt20-common/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/modules/atmosphere-gwt20-jackson/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-jackson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/modules/atmosphere-gwt20-jersey/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-jersey/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
     <groupId>org.atmosphere.extensions</groupId>

--- a/gwt20/modules/atmosphere-gwt20-managed/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-managed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/modules/atmosphere-gwt20-server/pom.xml
+++ b/gwt20/modules/atmosphere-gwt20-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/modules/pom.xml
+++ b/gwt20/modules/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.atmosphere.extensions</groupId>
         <artifactId>atmosphere-gwt20-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gwt20/pom.xml
+++ b/gwt20/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.atmosphere.extensions</groupId>
     <artifactId>atmosphere-gwt20-project</artifactId>
     <name>atmosphere-gwt20-project</name>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/Atmosphere/atmosphere-extensions/gwt20</url>

--- a/hazelcast/modules/pom.xml
+++ b/hazelcast/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-hazelcast</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-hazelcast</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/jgroups/modules/pom.xml
+++ b/jgroups/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-jgroups</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-jgroups</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/jms/modules/pom.xml
+++ b/jms/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-jms</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-jms</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/kafka/modules/pom.xml
+++ b/kafka/modules/pom.xml
@@ -3,14 +3,14 @@
 	<parent>
 		<groupId>org.atmosphere</groupId>
 		<artifactId>atmosphere-extensions-project</artifactId>
-		<version>2.4.22-SNAPSHOT</version>
+		<version>2.4.22-apriori</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.atmosphere</groupId>
 	<artifactId>atmosphere-kafka</artifactId>
 	<packaging>bundle</packaging>
-	<version>2.4.22-SNAPSHOT</version>
+	<version>2.4.22-apriori</version>
 	<name>atmosphere-kafka</name>
 	<url>https://github.com/Atmosphere/atmosphere</url>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>atmosphere-extensions-project</artifactId>
     <packaging>pom</packaging>
     <name>atmosphere-extensions-project</name>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <url>http://github.com/Atmosphere/atmosphere-extensions</url>
     <scm>
         <connection>scm:git:git@github.com:Atmosphere/atmosphere-extensions.git</connection>
@@ -346,6 +346,10 @@
         </pluginRepository>
     </pluginRepositories>
     <repositories>
+        <repository>
+            <id>thirdparty</id>
+            <url>https://nexus.apriori.com/content/repositories/thirdparty/</url>
+        </repository>
         <repository>
             <id>oss.sonatype.org</id>
             <url>http://oss.sonatype.org/content/repositories/releases</url>

--- a/rabbitmq/modules/pom.xml
+++ b/rabbitmq/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-rabbitmq</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-rabbitmq</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/redis-redisson/modules/pom.xml
+++ b/redis-redisson/modules/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>atmosphere-redis-redisson</artifactId>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <dependencies>
         <dependency>
             <groupId>org.redisson</groupId>

--- a/redis/modules/pom.xml
+++ b/redis/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-redis</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-redis</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/rmi/modules/pom.xml
+++ b/rmi/modules/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/socketio/modules/pom.xml
+++ b/socketio/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.atmosphere</groupId>
 	<artifactId>atmosphere-socketio</artifactId>
 	<packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
 	<name>atmosphere-socketio</name>
 	<url>https://github.com/Atmosphere/atmosphere</url>
 	<build>

--- a/sockjs/modules/pom.xml
+++ b/sockjs/modules/pom.xml
@@ -3,14 +3,14 @@
 	<parent>
 		<groupId>org.atmosphere</groupId>
 		<artifactId>atmosphere-extensions-project</artifactId>
-		<version>2.4.22-SNAPSHOT</version>
+		<version>2.4.22-apriori</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.atmosphere</groupId>
 	<artifactId>atmosphere-sockjs</artifactId>
 	<packaging>bundle</packaging>
-	<version>2.4.22-SNAPSHOT</version>
+	<version>2.4.22-apriori</version>
 	<name>atmosphere-sockjs</name>
 	<url>https://github.com/Atmosphere/atmosphere</url>
 	<build>

--- a/spring/modules/pom.xml
+++ b/spring/modules/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-spring</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-spring</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
 

--- a/weblogic/modules/pom.xml
+++ b/weblogic/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-weblogic</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-weblogic</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>

--- a/xmpp/modules/pom.xml
+++ b/xmpp/modules/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>atmosphere-extensions-project</artifactId>
-        <version>2.4.22-SNAPSHOT</version>
+        <version>2.4.22-apriori</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atmosphere</groupId>
     <artifactId>atmosphere-xmpp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.22-SNAPSHOT</version>
+    <version>2.4.22-apriori</version>
     <name>atmosphere-xmpp</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
     <build>


### PR DESCRIPTION
Created patch version 2.4.22-apriori where asyncClose flag in GWT client exists and sending Google analytics disabled during running tests