### PR TITLE
Update guice and mockito for JDK 17 build-time compatibility

### DIFF
--- a/hazelcast/modules/pom.xml
+++ b/hazelcast/modules/pom.xml
@@ -50,8 +50,8 @@
         </dependency>
         <dependency>
         	<groupId>org.mockito</groupId>
-        	<artifactId>mockito-all</artifactId>
-        	<version>1.8.4</version>
+        	<artifactId>mockito-core</artifactId>
+        	<version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jgroups/modules/pom.xml
+++ b/jgroups/modules/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.0</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
         <shade-version>1.2.1</shade-version>
         <felix-version>2.4.0</felix-version>
         <jms-version>1.1-rev-1</jms-version>
-        <guice-version>3.0</guice-version>
+        <guice-version>5.1.0</guice-version>
         <spring-version>6.1.3</spring-version>
         <wicket.version>1.4.12</wicket.version>
         <ahc.version>1.8.3</ahc.version>

--- a/rmi/modules/pom.xml
+++ b/rmi/modules/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.0</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- guice 3.0 -> 5.1
- mockito 1.x -> 4.11.0

Needed for [atmosphere#2484](https://github.com/Atmosphere/atmosphere/issues/2484).

Builds locally on JDK 8, 11 and 17.